### PR TITLE
feat: Configure dev server to run on port 3000

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 3000,
+  },
 })


### PR DESCRIPTION
As requested by the user, this change configures the Vite development server to run on port 3000. This is achieved by adding the `server.port` option to the `vite.config.js` file.