### PR TITLE
feat: Implement group video chat

### DIFF
--- a/src/components/chat/VoiceChatRoom.jsx
+++ b/src/components/chat/VoiceChatRoom.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { io } from 'socket.io-client';
-import { Mic, MicOff, PhoneCall, PhoneMissed, Send, MessageSquare, MoreHorizontal, Edit, Trash2, X, Paperclip, File as FileIcon } from 'lucide-react';
+import { Mic, MicOff, PhoneCall, PhoneMissed, Send, MessageSquare, MoreHorizontal, Edit, Trash2, X, Paperclip, File as FileIcon, Video, VideoOff } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { collection, query, onSnapshot, doc, setDoc, deleteDoc, serverTimestamp, addDoc, updateDoc, Timestamp, orderBy } from 'firebase/firestore';
 import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
@@ -26,6 +26,7 @@ const VoiceChatRoom = () => {
   const [uidSocketMap, setUidSocketMap] = useState({});
   const [speakingState, setSpeakingState] = useState({});
   const [isMuted, setIsMuted] = useState(false);
+  const [isVideoEnabled, setIsVideoEnabled] = useState(true);
   const [isJoined, setIsJoined] = useState(false);
   const [messages, setMessages] = useState([]);
   const [inputMessage, setInputMessage] = useState('');
@@ -38,6 +39,7 @@ const VoiceChatRoom = () => {
   const [uploadingFile, setUploadingFile] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [roomBackground, setRoomBackground] = useState(null);
+  const [remoteStreams, setRemoteStreams] = useState({});
 
   // Simulate fetching equipped background from user's profile
   useEffect(() => {
@@ -53,12 +55,15 @@ const VoiceChatRoom = () => {
     localStreamRef.current?.getTracks().forEach(track => pc.addTrack(track, localStreamRef.current));
     pc.onicecandidate = e => e.candidate && socketRef.current.emit('webrtc-ice-candidate', { targetSocketId, candidate: e.candidate });
     pc.ontrack = (event) => {
-      let audioEl = document.getElementById(targetSocketId);
-      if (!audioEl) { audioEl = document.createElement('audio'); audioEl.id = targetSocketId; audioEl.autoplay = true; audioContainerRef.current?.appendChild(audioEl); }
-      audioEl.srcObject = event.streams[0];
+      setRemoteStreams(prev => ({
+        ...prev,
+        [targetSocketId]: event.streams[0]
+      }));
+
+      const audioStream = event.streams[0];
       const audioContext = new AudioContext();
       const analyser = audioContext.createAnalyser();
-      const source = audioContext.createMediaStreamSource(event.streams[0]);
+      const source = audioContext.createMediaStreamSource(audioStream);
       source.connect(analyser);
       analyser.fftSize = 512;
       const dataArray = new Uint8Array(analyser.frequencyBinCount);
@@ -79,10 +84,28 @@ const VoiceChatRoom = () => {
   useEffect(() => { if (!db || !roomId) return; const q = query(collection(db, getVoiceRoomParticipantsPath(appId, roomId))); const unsub = onSnapshot(q, (snap) => setParticipants(snap.docs.map(d => ({ id: d.id, ...d.data() })))); return unsub; }, [db, roomId, appId]);
   useEffect(() => { if (!db || !roomId) return; const q = query(collection(db, getVoiceRoomMessagesPath(appId, roomId)), orderBy('createdAt')); const unsub = onSnapshot(q, (snap) => { setMessages(snap.docs.map(d => ({ id: d.id, ...d.data() }))); setIsLoadingMessages(false); }); return unsub; }, [db, roomId, appId]);
   useEffect(() => { if (!db || !roomId) return; const typingStatusPath = `${getVoiceRoomPath(appId, roomId)}/typing_status`; const q = query(collection(db, typingStatusPath)); const unsub = onSnapshot(q, (snap) => { const now = Date.now(); setTypingUsers(snap.docs.filter(d => d.id !== user.uid && (now - d.data().lastTyped.toMillis()) < 3000).map(d => d.data().name)); }); return unsub; }, [db, roomId, appId, user.uid]);
-  useEffect(() => { const socket = io(import.meta.env.VITE_SIGNALING_SERVER_URL || 'http://localhost:3001'); socketRef.current = socket; socket.emit('join-room', roomId, user.uid); socket.on('user-joined', (newUserId, newSocketId) => createPeerConnection(newSocketId, true)); socket.on('room-state', setUidSocketMap); socket.on('webrtc-offer', async ({ senderSocketId, sdp }) => { const pc = createPeerConnection(senderSocketId, false); await pc.setRemoteDescription(new RTCSessionDescription(sdp)); const answer = await pc.createAnswer(); await pc.setLocalDescription(answer); socket.emit('webrtc-answer', { targetSocketId: senderSocketId, sdp: pc.localDescription }); }); socket.on('webrtc-answer', async ({ senderSocketId, sdp }) => { await peerConnectionsRef.current[senderSocketId]?.setRemoteDescription(new RTCSessionDescription(sdp)); }); socket.on('webrtc-ice-candidate', ({ senderSocketId, candidate }) => { peerConnectionsRef.current[senderSocketId]?.addIceCandidate(new RTCIceCandidate(candidate)); }); socket.on('user-left', (socketId) => { peerConnectionsRef.current[socketId]?.close(); delete peerConnectionsRef.current[socketId]; clearInterval(audioIntervalsRef.current[socketId]); delete audioIntervalsRef.current[socketId]; setSpeakingState(p => { const n = {...p}; delete n[socketId]; return n; }); document.getElementById(socketId)?.remove(); }); return () => { localStreamRef.current?.getTracks().forEach(t => t.stop()); Object.values(peerConnectionsRef.current).forEach(pc => pc.close()); Object.values(audioIntervalsRef.current).forEach(i => clearInterval(i)); socket.disconnect(); }; }, [roomId, user.uid, createPeerConnection]);
+  useEffect(() => { const socket = io(import.meta.env.VITE_SIGNALING_SERVER_URL || 'http://localhost:3001'); socketRef.current = socket; socket.emit('join-room', roomId, user.uid); socket.on('user-joined', (newUserId, newSocketId) => createPeerConnection(newSocketId, true)); socket.on('room-state', setUidSocketMap); socket.on('webrtc-offer', async ({ senderSocketId, sdp }) => { const pc = createPeerConnection(senderSocketId, false); await pc.setRemoteDescription(new RTCSessionDescription(sdp)); const answer = await pc.createAnswer(); await pc.setLocalDescription(answer); socket.emit('webrtc-answer', { targetSocketId: senderSocketId, sdp: pc.localDescription }); }); socket.on('webrtc-answer', async ({ senderSocketId, sdp }) => { await peerConnectionsRef.current[senderSocketId]?.setRemoteDescription(new RTCSessionDescription(sdp)); }); socket.on('webrtc-ice-candidate', ({ senderSocketId, candidate }) => { peerConnectionsRef.current[senderSocketId]?.addIceCandidate(new RTCIceCandidate(candidate)); }); socket.on('user-left', (socketId) => { peerConnectionsRef.current[socketId]?.close(); delete peerConnectionsRef.current[socketId]; clearInterval(audioIntervalsRef.current[socketId]); delete audioIntervalsRef.current[socketId]; setSpeakingState(p => { const n = {...p}; delete n[socketId]; return n; }); setRemoteStreams(p => { const n = {...p}; delete n[socketId]; return n; }); document.getElementById(socketId)?.remove(); }); return () => { localStreamRef.current?.getTracks().forEach(t => t.stop()); Object.values(peerConnectionsRef.current).forEach(pc => pc.close()); Object.values(audioIntervalsRef.current).forEach(i => clearInterval(i)); socket.disconnect(); }; }, [roomId, user.uid, createPeerConnection]);
   useEffect(() => { messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [messages]);
 
-  const startVoiceChat = async () => { try { localStreamRef.current = await navigator.mediaDevices.getUserMedia({ audio: true }); setIsJoined(true); await setDoc(doc(db, getVoiceRoomParticipantsPath(appId, roomId), user.uid), { name: userProfile.name, avatar: userProfile.avatar, uid: user.uid, joinedAt: serverTimestamp() }); } catch (error) { console.error("Mic error:", error); } };
+  const joinRoom = async () => {
+    try {
+      localStreamRef.current = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+      setIsVideoEnabled(true);
+      setIsJoined(true);
+      await setDoc(doc(db, getVoiceRoomParticipantsPath(appId, roomId), user.uid), { name: userProfile.name, avatar: userProfile.avatar, uid: user.uid, joinedAt: serverTimestamp() });
+    } catch (error) {
+      console.error("Mic/Camera error, falling back to audio only:", error);
+      try {
+        localStreamRef.current = await navigator.mediaDevices.getUserMedia({ audio: true });
+        setIsVideoEnabled(false);
+        setIsJoined(true);
+        await setDoc(doc(db, getVoiceRoomParticipantsPath(appId, roomId), user.uid), { name: userProfile.name, avatar: userProfile.avatar, uid: user.uid, joinedAt: serverTimestamp() });
+      } catch (audioError) {
+        console.error("Audio-only fallback error:", audioError);
+        alert("Could not get microphone access. Please check permissions.");
+      }
+    }
+  };
   const endVoiceChat = async () => { await deleteDoc(doc(db, getVoiceRoomParticipantsPath(appId, roomId), user.uid)); socketRef.current.disconnect(); navigate('/dashboard'); };
   const toggleMute = () => { if(localStreamRef.current) { const audioTrack = localStreamRef.current.getAudioTracks()[0]; audioTrack.enabled = !isMuted; setIsMuted(!isMuted); }};
   const sendDbMessage = async (messageData) => { const finalMessage = { ...messageData, senderId: user.uid, senderName: userProfile.name, createdAt: serverTimestamp(), isEdited: false, replyTo: replyingToMessage ? { id: replyingToMessage.id, text: replyingToMessage.text, senderName: replyingToMessage.senderName } : null }; await addDoc(collection(db, getVoiceRoomMessagesPath(appId, roomId)), finalMessage); setReplyingToMessage(null); };
@@ -96,6 +119,33 @@ const VoiceChatRoom = () => {
   const startEditing = (msg) => { setEditingMessageId(msg.id); setEditingText(msg.text); setShowOptionsForMessageId(null); };
   const startReplying = (msg) => { setReplyingToMessage(msg); setShowOptionsForMessageId(null); };
   const findSocketIdByUid = (uid) => uidSocketMap[uid] || null;
+
+  const toggleVideo = () => {
+    if (localStreamRef.current) {
+      const videoTrack = localStreamRef.current.getVideoTracks()[0];
+      if (videoTrack) {
+        videoTrack.enabled = !isVideoEnabled;
+        setIsVideoEnabled(!isVideoEnabled);
+      }
+    }
+  };
+
+  const ParticipantVideo = ({ stream, participant }) => {
+    const videoRef = useRef(null);
+    useEffect(() => {
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+      }
+    }, [stream]);
+
+    return (
+      <div className="relative aspect-video bg-gray-950 rounded-lg overflow-hidden">
+        <video ref={videoRef} autoPlay playsInline className="w-full h-full object-cover" />
+        <div className="absolute bottom-2 left-2 bg-black bg-opacity-50 px-2 py-1 rounded-md text-sm">{participant.name}</div>
+      </div>
+    );
+  };
+
   const ReplyQuote = ({ msg }) => <div className="p-2 mb-1 text-xs bg-gray-800 rounded-lg"><p className="font-bold text-gray-400">{msg.senderName}</p><p className="opacity-80 truncate">{msg.text}</p></div>;
 
   return (
@@ -105,8 +155,38 @@ const VoiceChatRoom = () => {
     >
       <div className="md:col-span-3 flex flex-col h-screen bg-black bg-opacity-50">
         <header className="flex justify-between items-center p-4 border-b border-gray-700 bg-black bg-opacity-30"><h1 className="text-xl font-bold">Room: {roomId}</h1><button onClick={() => navigate('/dashboard')} className="p-2 rounded-full bg-gray-700 hover:bg-gray-600"><X size={20}/></button></header>
-        <div className="flex-grow p-4 overflow-y-auto"><div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">{participants.map(p => (<div key={p.id} className={`relative flex flex-col items-center p-2 rounded-lg transition-all duration-200 ${speakingState[findSocketIdByUid(p.id)] ? 'border-2 border-green-400' : ''}`}><img src={p.avatar} alt={p.name} className="w-24 h-24 rounded-full mb-2" /><p className="font-semibold text-center text-sm">{p.name}</p></div>))}</div></div>
-        <footer className="p-4 bg-gray-950 flex justify-center items-center space-x-4 border-t border-gray-700"><button onClick={isJoined ? endVoiceChat : startVoiceChat} className={`p-4 rounded-full text-white shadow-lg ${isJoined ? 'bg-red-600' : 'bg-green-600'}`}>{isJoined ? <PhoneMissed /> : <PhoneCall />}</button>{isJoined && <button onClick={toggleMute} className={`p-4 rounded-full shadow-lg ${isMuted ? 'bg-gray-600' : 'bg-blue-600'}`}>{isMuted ? <MicOff /> : <Mic />}</button>}</footer>
+        <div className="flex-grow p-4 overflow-y-auto">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+            {/* Local User's Video */}
+            {isJoined && (
+              <div className="relative aspect-video bg-gray-950 rounded-lg overflow-hidden">
+                <video ref={el => { if (el && localStreamRef.current) el.srcObject = localStreamRef.current; }} autoPlay muted playsInline className="w-full h-full object-cover" />
+                <div className="absolute bottom-2 left-2 bg-black bg-opacity-50 px-2 py-1 rounded-md text-sm">{userProfile.name} (You)</div>
+              </div>
+            )}
+            {participants.filter(p => p.id !== user.uid).map(p => {
+              const socketId = findSocketIdByUid(p.id);
+              const stream = remoteStreams[socketId];
+              return stream ? (
+                <ParticipantVideo key={p.id} stream={stream} participant={p} />
+              ) : (
+                <div key={p.id} className="relative aspect-video bg-gray-950 rounded-lg overflow-hidden flex items-center justify-center">
+                  <img src={p.avatar} alt={p.name} className="w-24 h-24 rounded-full" />
+                  <div className="absolute bottom-2 left-2 bg-black bg-opacity-50 px-2 py-1 rounded-md text-sm">{p.name}</div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        <footer className="p-4 bg-gray-950 flex justify-center items-center space-x-4 border-t border-gray-700">
+          <button onClick={isJoined ? endVoiceChat : joinRoom} className={`p-4 rounded-full text-white shadow-lg ${isJoined ? 'bg-red-600' : 'bg-green-600'}`}>{isJoined ? <PhoneMissed /> : <PhoneCall />}</button>
+          {isJoined && (
+            <>
+              <button onClick={toggleMute} className={`p-4 rounded-full shadow-lg ${isMuted ? 'bg-gray-600' : 'bg-blue-600'}`}>{isMuted ? <MicOff /> : <Mic />}</button>
+              <button onClick={toggleVideo} className={`p-4 rounded-full shadow-lg ${!isVideoEnabled ? 'bg-gray-600' : 'bg-blue-600'}`}>{isVideoEnabled ? <Video /> : <VideoOff />}</button>
+            </>
+          )}
+        </footer>
       </div>
       <div className="md:col-span-1 flex flex-col bg-gray-800 border-l border-gray-700 h-screen">
         <div className="p-4 border-b border-gray-700"><h2 className="text-xl font-bold">Chat</h2></div>


### PR DESCRIPTION
This commit enhances the existing voice chat rooms to support multi-party video conferencing.

- Updates the `VoiceChatRoom` UI to a video-first grid layout, displaying video feeds for all participants.
- Adds controls for enabling and disabling the user's camera.
- Modifies the WebRTC logic to request camera permissions and include video tracks in the RTCPeerConnection.
- Implements the necessary handlers (`ontrack`, `user-left`) to dynamically add and remove remote video streams from the UI.
- Includes a fallback to an audio-only mode if camera access is denied.