### PR TITLE
feat: Add session recording and playback feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import LiveStream from './components/stream/LiveStream';
 import VirtualStore from './components/store/VirtualStore';
 import InventoryScreen from './components/store/InventoryScreen';
 import ThreeDRoom from './components/world/ThreeDRoom';
+import MyRecordings from './components/recordings/MyRecordings';
 
 // ProtectedRoute component to guard routes that require authentication
 const ProtectedRoute = () => {
@@ -104,6 +105,7 @@ const AppContent = () => {
           <Route path="/store" element={<VirtualStore />} />
           <Route path="/inventory" element={<InventoryScreen />} />
           <Route path="/world" element={<ThreeDRoom />} />
+          <Route path="/my-recordings" element={<MyRecordings />} />
         </Route>
 
         {/* Redirect any unknown paths to the home page if logged in, or login if not */}

--- a/src/components/chat/VoiceChatRoom.jsx
+++ b/src/components/chat/VoiceChatRoom.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { io } from 'socket.io-client';
-import { Mic, MicOff, PhoneCall, PhoneMissed, Send, MessageSquare, MoreHorizontal, Edit, Trash2, X, Paperclip, File as FileIcon, Video, VideoOff } from 'lucide-react';
+import { Mic, MicOff, PhoneCall, PhoneMissed, Send, MessageSquare, MoreHorizontal, Edit, Trash2, X, Paperclip, File as FileIcon, Video, VideoOff, Circle } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { collection, query, onSnapshot, doc, setDoc, deleteDoc, serverTimestamp, addDoc, updateDoc, Timestamp, orderBy } from 'firebase/firestore';
 import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
@@ -21,6 +21,8 @@ const VoiceChatRoom = () => {
   const audioIntervalsRef = useRef({});
   const messagesEndRef = useRef(null);
   const fileInputRef = useRef(null);
+  const mediaRecorderRef = useRef(null);
+  const recordedChunksRef = useRef([]);
 
   const [participants, setParticipants] = useState([]);
   const [uidSocketMap, setUidSocketMap] = useState({});
@@ -40,6 +42,8 @@ const VoiceChatRoom = () => {
   const [uploadProgress, setUploadProgress] = useState(0);
   const [roomBackground, setRoomBackground] = useState(null);
   const [remoteStreams, setRemoteStreams] = useState({});
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordingUploadProgress, setRecordingUploadProgress] = useState(null);
 
   // Simulate fetching equipped background from user's profile
   useEffect(() => {
@@ -120,6 +124,74 @@ const VoiceChatRoom = () => {
   const startReplying = (msg) => { setReplyingToMessage(msg); setShowOptionsForMessageId(null); };
   const findSocketIdByUid = (uid) => uidSocketMap[uid] || null;
 
+  const uploadRecording = (blob) => {
+    if (!storage || !db || !user) return;
+    const recordingRef = ref(storage, `room_recordings/${roomId}/${user.uid}_${Date.now()}.webm`);
+    const uploadTask = uploadBytesResumable(recordingRef, blob);
+
+    uploadTask.on('state_changed',
+      (snapshot) => {
+        const progress = (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+        setRecordingUploadProgress(progress);
+      },
+      (error) => {
+        console.error("Recording upload failed:", error);
+        alert("Your recording failed to upload.");
+        setRecordingUploadProgress(null);
+      },
+      () => {
+        getDownloadURL(uploadTask.snapshot.ref).then(async (downloadURL) => {
+          const recordingsColPath = `apps/${appId}/recordings`;
+          await addDoc(collection(db, recordingsColPath), {
+            roomId,
+            userId: user.uid,
+            userName: userProfile.name,
+            url: downloadURL,
+            createdAt: serverTimestamp(),
+            duration: 0 // Placeholder for duration
+          });
+          alert("Recording uploaded successfully!");
+          setRecordingUploadProgress(null);
+        });
+      }
+    );
+  };
+
+  const startRecording = () => {
+    if (localStreamRef.current) {
+      recordedChunksRef.current = [];
+      // Prefer webm but fallback if not supported
+      const mimeType = MediaRecorder.isTypeSupported('video/webm; codecs=vp9')
+        ? 'video/webm; codecs=vp9'
+        : 'video/webm';
+      mediaRecorderRef.current = new MediaRecorder(localStreamRef.current, { mimeType });
+
+      mediaRecorderRef.current.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          recordedChunksRef.current.push(event.data);
+        }
+      };
+
+      mediaRecorderRef.current.onstop = () => {
+        const blob = new Blob(recordedChunksRef.current, { type: mimeType });
+        uploadRecording(blob);
+        recordedChunksRef.current = [];
+      };
+
+      mediaRecorderRef.current.start();
+      setIsRecording(true);
+    } else {
+      alert("You must join the room to start recording.");
+    }
+  };
+
+  const stopRecording = () => {
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state === "recording") {
+      mediaRecorderRef.current.stop();
+      setIsRecording(false);
+    }
+  };
+
   const toggleVideo = () => {
     if (localStreamRef.current) {
       const videoTrack = localStreamRef.current.getVideoTracks()[0];
@@ -154,7 +226,16 @@ const VoiceChatRoom = () => {
       style={{ backgroundImage: roomBackground ? `url(${roomBackground})` : 'none', backgroundColor: !roomBackground ? '#1f2937' : 'transparent' }}
     >
       <div className="md:col-span-3 flex flex-col h-screen bg-black bg-opacity-50">
-        <header className="flex justify-between items-center p-4 border-b border-gray-700 bg-black bg-opacity-30"><h1 className="text-xl font-bold">Room: {roomId}</h1><button onClick={() => navigate('/dashboard')} className="p-2 rounded-full bg-gray-700 hover:bg-gray-600"><X size={20}/></button></header>
+        <header className="flex justify-between items-center p-4 border-b border-gray-700 bg-black bg-opacity-30">
+          <h1 className="text-xl font-bold">Room: {roomId}</h1>
+          {isRecording && (
+            <div className="flex items-center space-x-2 animate-pulse">
+              <Circle className="text-red-500" size={16} fill="red" />
+              <span className="text-red-500 font-semibold">REC</span>
+            </div>
+          )}
+          <button onClick={() => navigate('/dashboard')} className="p-2 rounded-full bg-gray-700 hover:bg-gray-600"><X size={20}/></button>
+        </header>
         <div className="flex-grow p-4 overflow-y-auto">
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
             {/* Local User's Video */}
@@ -184,6 +265,9 @@ const VoiceChatRoom = () => {
             <>
               <button onClick={toggleMute} className={`p-4 rounded-full shadow-lg ${isMuted ? 'bg-gray-600' : 'bg-blue-600'}`}>{isMuted ? <MicOff /> : <Mic />}</button>
               <button onClick={toggleVideo} className={`p-4 rounded-full shadow-lg ${!isVideoEnabled ? 'bg-gray-600' : 'bg-blue-600'}`}>{isVideoEnabled ? <Video /> : <VideoOff />}</button>
+              <button onClick={isRecording ? stopRecording : startRecording} className={`p-4 rounded-full shadow-lg ${isRecording ? 'bg-red-700 animate-pulse' : 'bg-red-500'}`}>
+                <Circle />
+              </button>
             </>
           )}
         </footer>
@@ -193,7 +277,8 @@ const VoiceChatRoom = () => {
         <div className="flex-1 p-4 overflow-y-auto custom-scrollbar">{isLoadingMessages ? <div className="flex justify-center items-center h-full"><div className="w-8 h-8 border-2 border-dashed rounded-full animate-spin border-blue-500"></div></div> : messages.map(message => (<div key={message.id} className={`group relative my-2 flex flex-col ${message.senderId === user.uid ? 'items-end' : 'items-start'}`}><div className={`px-3 py-2 rounded-lg max-w-xs ${message.senderId === user.uid ? 'bg-blue-600' : 'bg-gray-700'}`}><p className="text-xs font-bold text-gray-400">{message.senderName}</p>{message.replyTo && <ReplyQuote msg={message.replyTo} />}{editingMessageId === message.id ? ( <form onSubmit={handleUpdateMessage}><input type="text" value={editingText} onChange={(e) => setEditingText(e.target.value)} className="w-full bg-blue-700 text-white rounded p-1" autoFocus/><div className="flex justify-end space-x-2 mt-1"><button type="button" onClick={() => setEditingMessageId(null)} className="text-xs">Cancel</button><button type="submit" className="text-xs font-bold">Save</button></div></form>) : (message.type === 'image' ? <img src={message.file.url} alt={message.file.name} className="rounded-lg max-w-full h-auto mt-1" /> : message.type === 'file' ? <a href={message.file.url} target="_blank" rel="noopener noreferrer" className="flex items-center underline text-blue-300"><FileIcon className="mr-2"/>{message.file.name}</a> : <p className="text-sm break-words">{message.text}</p>)}<p className="text-xs text-gray-400 mt-1 text-right">{message.isEdited && <i>(edited)</i>}</p></div>{message.senderId === user.uid && (<div className="absolute left-0 top-1/2 -translate-y-1/2 flex items-center opacity-0 group-hover:opacity-100"><button onClick={() => setShowOptionsForMessageId(showOptionsForMessageId === message.id ? null : message.id)} className="p-1 rounded-full hover:bg-gray-600"><MoreHorizontal size={14}/></button>{showOptionsForMessageId === message.id && (<div className="absolute left-full ml-1 w-28 bg-gray-900 border border-gray-700 rounded shadow-lg z-10 py-1"><button onClick={() => startReplying(message)} className="w-full text-left text-sm px-3 py-1.5 hover:bg-gray-700 flex items-center"><MessageSquare size={14} className="mr-2"/> Reply</button>{message.type === 'text' && <button onClick={() => startEditing(message)} className="w-full text-left text-sm px-3 py-1.5 hover:bg-gray-700 flex items-center"><Edit size={14} className="mr-2"/> Edit</button>}<button onClick={() => handleDeleteMessage(message.id)} className="w-full text-left text-sm px-3 py-1.5 text-red-400 hover:bg-gray-700 flex items-center"><Trash2 size={14} className="mr-2"/> Delete</button></div>)}</div>)}</div>))}<div ref={messagesEndRef} /></div>
         <div className="h-5 text-sm text-gray-400 italic px-4">{typingUsers.length > 0 && `${typingUsers.join(', ')} is typing...`}</div>
         {uploadingFile && <div className="p-4"><p className="text-sm">Uploading: {uploadingFile.name}</p><div className="w-full bg-gray-700 rounded-full h-2.5"><div className="bg-blue-600 h-2.5 rounded-full" style={{width: `${uploadProgress}%`}}></div></div></div>}
-        <div className="p-4 border-t border-gray-700">{replyingToMessage && <div className="p-2 mb-2 bg-gray-700 rounded-lg text-sm flex justify-between items-center"><div><p className="font-bold">Replying to {replyingToMessage.senderName}</p><p className="opacity-80 truncate">{replyingToMessage.text}</p></div><button onClick={() => setReplyingToMessage(null)} className="p-1"><X size={16}/></button></div>}<form onSubmit={handleSendMessage} className="flex items-center space-x-2"><input type="file" ref={fileInputRef} onChange={handleFileChange} className="hidden" /><button type="button" onClick={() => fileInputRef.current.click()} className="p-2 rounded-full bg-gray-700 hover:bg-gray-600"><Paperclip size={20}/></button><input type="text" value={inputMessage} onChange={handleInputChange} placeholder="Send a message..." className="flex-1 p-2 rounded-full bg-gray-700 focus:outline-none"/><button type="submit" disabled={uploadingFile} className="p-2 rounded-full bg-blue-600"><Send size={20}/></button></form></div>
+        {recordingUploadProgress !== null && <div className="p-4"><p className="text-sm">Uploading Recording...</p><div className="w-full bg-gray-700 rounded-full h-2.5"><div className="bg-purple-600 h-2.5 rounded-full" style={{width: `${recordingUploadProgress}%`}}></div></div></div>}
+        <div className="p-4 border-t border-gray-700">{replyingToMessage && <div className="p-2 mb-2 bg-gray-700 rounded-lg text-sm flex justify-between items-center"><div><p className="font-bold">Replying to {replyingToMessage.senderName}</p><p className="opacity-80 truncate">{replyingToMessage.text}</p></div><button onClick={() => setReplyingToMessage(null)} className="p-1"><X size={16}/></button></div>}<form onSubmit={handleSendMessage} className="flex items-center space-x-2"><input type="file" ref={fileInputRef} onChange={handleFileChange} className="hidden" /><button type="button" onClick={() => fileInputRef.current.click()} className="p-2 rounded-full bg-gray-700 hover:bg-gray-600"><Paperclip size={20}/></button><input type="text" value={inputMessage} onChange={handleInputChange} placeholder="Send a message..." className="flex-1 p-2 rounded-full bg-gray-700 focus:outline-none"/><button type="submit" disabled={uploadingFile || recordingUploadProgress !== null} className="p-2 rounded-full bg-blue-600"><Send size={20}/></button></form></div>
       </div>
       <div ref={audioContainerRef} />
     </div>

--- a/src/components/core/HomeScreen.jsx
+++ b/src/components/core/HomeScreen.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { LogOut, Users, User as UserIcon, Home, Bell, Sun, Radio, LifeBuoy } from 'lucide-react';
+import { LogOut, Users, User as UserIcon, Home, Bell, Sun, Radio, LifeBuoy, Clapperboard } from 'lucide-react';
 import io from 'socket.io-client';
 import { ThemeContext } from '../../context/ThemeContext';
 import { useAuth } from '../../context/AuthContext';
@@ -63,6 +63,7 @@ const HomeScreen = ({ onToggleNotifications, hasNotifications }) => {
           <button onClick={toggleDarkMode} className="p-2 rounded-full hover:bg-gray-700"><Sun className="w-6 h-6 text-yellow-500" /></button>
           <button onClick={() => navigate('/profile')} className="p-2 rounded-full hover:bg-gray-700" title="Profile"><UserIcon className="w-6 h-6 text-blue-500" /></button>
           <button onClick={() => navigate('/friends')} className="p-2 rounded-full hover:bg-gray-700" title="Friends"><Users className="w-6 h-6 text-pink-500" /></button>
+          <button onClick={() => navigate('/my-recordings')} className="p-2 rounded-full hover:bg-gray-700" title="My Recordings"><Clapperboard className="w-6 h-6 text-purple-500" /></button>
           <button onClick={() => navigate(`/chat/${SUPPORT_BOT_ID}/${SUPPORT_BOT_NAME}`)} className="p-2 rounded-full hover:bg-gray-700" title="Help & Support"><LifeBuoy className="w-6 h-6 text-green-500" /></button>
           <button onClick={onToggleNotifications} className="p-2 rounded-full hover:bg-gray-700 relative"><Bell className="w-6 h-6 text-white" />{hasNotifications && <span className="absolute top-1 right-1 block h-2 w-2 rounded-full ring-2 ring-gray-900 bg-red-500"></span>}</button>
           <button onClick={handleLogout} className="px-4 py-2 bg-red-600 text-white rounded-full font-bold shadow-lg hover:bg-red-700"><LogOut className="w-4 h-4 inline-block ms-1" /> Logout</button>

--- a/src/components/recordings/MyRecordings.jsx
+++ b/src/components/recordings/MyRecordings.jsx
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { useAuth } from '../../context/AuthContext';
+import { collection, query, where, orderBy, getDocs } from 'firebase/firestore';
+import { Link } from 'react-router-dom';
+
+const MyRecordings = () => {
+  const { user, db, appId } = useAuth();
+  const [recordings, setRecordings] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchRecordings = async () => {
+      if (!db || !user) {
+        setLoading(false);
+        return;
+      }
+      try {
+        const recordingsColPath = `apps/${appId}/recordings`;
+        const q = query(
+          collection(db, recordingsColPath),
+          where('userId', '==', user.uid),
+          orderBy('createdAt', 'desc')
+        );
+        const querySnapshot = await getDocs(q);
+        const recordingsList = querySnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        setRecordings(recordingsList);
+      } catch (error) {
+        console.error("Error fetching recordings:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRecordings();
+  }, [db, user, appId]);
+
+  if (loading) {
+    return <div className="text-center p-10">Loading your recordings...</div>;
+  }
+
+  return (
+    <div className="p-8 bg-gray-900 text-white min-h-screen">
+      <h1 className="text-4xl font-bold mb-8 text-center">My Recordings</h1>
+      <div className="max-w-4xl mx-auto">
+        {recordings.length === 0 ? (
+          <p className="text-center text-gray-400">You have no recordings yet.</p>
+        ) : (
+          <ul className="space-y-4">
+            {recordings.map(rec => (
+              <li key={rec.id} className="bg-gray-800 p-4 rounded-lg flex justify-between items-center">
+                <div>
+                  <p className="font-semibold">Recording from Room: {rec.roomId}</p>
+                  <p className="text-sm text-gray-400">
+                    Recorded on: {new Date(rec.createdAt?.toDate()).toLocaleString()}
+                  </p>
+                </div>
+                <a
+                  href={rec.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+                >
+                  Watch
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MyRecordings;


### PR DESCRIPTION
This commit introduces the capability for users to record their sessions and view them later.

- Implements client-side recording logic using MediaRecorder API.
- Adds UI controls and indicators for recording in the video room.
- Simulates uploading the recorded blob to Firebase Storage and saves the metadata to a new 'recordings' collection in Firestore.
- Creates a new 'My Recordings' page to list and play back saved recordings.
- Integrates the new page with routing and navigation.